### PR TITLE
rm ref and depends on

### DIFF
--- a/src/app/docs/model.html
+++ b/src/app/docs/model.html
@@ -36,8 +36,6 @@
                 <li ui-sref-active='active'><a ui-sref="dbt.model({'#': 'details'})">Details</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.model({'#': 'description'})">Description</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.model({'#': 'columns'})">Columns</a></li>
-                <li ui-sref-active='active' ng-show = "referencesLength != 0"><a ui-sref="dbt.model({'#': 'referenced_by'})">Referenced By</a></li>
-                <li ui-sref-active='active' ng-show = "parentsLength != 0"><a ui-sref="dbt.model({'#': 'depends_on'})">Depends On</a></li>
                 <li ui-sref-active='active'><a ui-sref="dbt.model({'#': 'code'})">Code</a></li>
             </ul>
         </div>
@@ -67,22 +65,6 @@
                 <div class="section-content">
                     <h6>Columns</h6>
                     <column-details model="model" />
-                </div>
-            </section>
-
-            <section class="section" ng-show = "referencesLength != 0">
-                <div class="section-target" id="referenced_by"></div>
-                <div class="section-content">
-                    <h6>Referenced By</h6>
-                    <reference-list references="references" node="model" />
-                </div>
-            </section>
-
-            <section class="section" ng-show = "parentsLength != 0">
-                <div class="section-target" id="depends_on"></div>
-                <div class="section-content">
-                    <h6>Depends On</h6>
-                    <reference-list references="parents" node="model" />
                 </div>
             </section>
 


### PR DESCRIPTION
hides the `referenced by` and `depends` on fields and sections completely 

in order to deploy the docs site we will need to check in the latest `catalog.json` and `manifest.json` from dbt and then run 

```
npm install
npx webpack
```

which will build an index.html in the `dist/` dir 

We will then push these artifacts to S3 and host the static site using cloudfront. I can prob automate all this in circle